### PR TITLE
Add features from asar-tc ("import" and "undef" commands)

### DIFF
--- a/src/asar/asar.h
+++ b/src/asar/asar.h
@@ -9,7 +9,6 @@
 #pragma once
 #define Asar
 
-#include <libgen.h>
 #include "autoarray.h"
 #include "scapegoat.hpp"
 #include "libstr.h"

--- a/src/asar/asar.h
+++ b/src/asar/asar.h
@@ -9,6 +9,7 @@
 #pragma once
 #define Asar
 
+#include <libgen.h>
 #include "autoarray.h"
 #include "scapegoat.hpp"
 #include "libstr.h"

--- a/src/asar/assembleblock.cpp
+++ b/src/asar/assembleblock.cpp
@@ -687,7 +687,18 @@ void assembleblock(const char * block)
 		}
 		return;
 	}
-	if (is("if") || is("elseif") || is("assert") || is("while"))
+	if (is1("undef"))
+    {
+        string def;
+        if (*par=='!') def = S par+1;
+        else def = S par;
+        
+        string out;
+        if (defines.find(def, out)) {
+            defines.remove(def);
+        }
+    }
+	else if (is("if") || is("elseif") || is("assert") || is("while"))
 	{
 		if (emulatexkas) warn0("Convert the patch to native Asar format instead of making an Asar-only xkas patch.");
 		const char * errmsg=NULL;

--- a/src/asar/assembleblock.cpp
+++ b/src/asar/assembleblock.cpp
@@ -3,6 +3,7 @@
 #include "libsmw.h"
 #include "scapegoat.hpp"
 #include "autoarray.h"
+#include "platform/file-helpers.h"
 
 int arch=arch_65816;
 
@@ -133,6 +134,9 @@ int getnum(const char * str);
 void assemblefile(const char * filename, bool toplevel);
 extern const char * thisfilename;
 extern int thisline;
+
+extern const char * thisromname;
+extern const char * libdir;
 
 const char * createuserfunc(const char * name, const char * arguments, const char * content);
 
@@ -1365,7 +1369,7 @@ void assembleblock(const char * block)
 		repeatnext=rep;
 	}
 #ifdef SANDBOX
-	else if (is("incsrc") || is("incbin") || is("table"))
+	else if (is("incsrc") || is("incbin") || is("table") || is("incdir") || is("import"))
 	{
 		error(0, "This command is disabled.");
 	}
@@ -1393,6 +1397,15 @@ void assembleblock(const char * block)
 		if (emulatexkas) name=dequote(par);
 		else name=S dir(thisfilename)+dequote(par);
 		assemblefile(name, false);
+	}
+	else if (is1("import")) // import from search directory
+	{
+		checkbankcross();
+		string name;
+        name=S dir(strdup(thisromname)); // get starting directory (up from rom name)
+        name=S name+dir(libdir)+dequote(par); // and append lib directory
+        if (!file_exists(name)) name = S name + ".asm"; // if file doesn't exist, assume omitted .asm
+        assemblefile(name, false);
 	}
 	else if (is1("incbin") || is3("incbin"))
 	{

--- a/src/asar/interface-cli.cpp
+++ b/src/asar/interface-cli.cpp
@@ -45,6 +45,9 @@ extern const char * thisfilename;
 extern int thisline;
 extern const char * thisblock;
 
+extern const char * thisromname;
+extern const char * libdir;
+
 void print(const char * str)
 {
 	puts(str);
@@ -173,6 +176,10 @@ int main(int argc, char * argv[])
 				else if (par=="-pause=yes") pause=pause_yes;
 				else libcon_badusage();
 			}
+			else if (par=="-libdir")
+            {
+                libdir = libcon_option();
+            }
 			else libcon_badusage();
 		}
 		if (verbose)
@@ -183,6 +190,11 @@ int main(int argc, char * argv[])
 		string romname=libcon_optional_filename("Enter ROM name:", NULL);
 		//char * outname=libcon_optional_filename("Enter output ROM name:", NULL);
 		libcon_end();
+		if (!libdir)
+        {
+            // default to ./lib/ (relative to rom directory)
+            libdir = "./lib/";
+        }
 		if (!strchr(asmname, '.') && !file_exists(asmname)) asmname+=".asm";
 		if (!romname)
 		{
@@ -198,6 +210,7 @@ int main(int argc, char * argv[])
 			if (file_exists(S romname+".sfc")) romname+=".sfc";
 			else if (file_exists(S romname+".smc")) romname+=".smc";
 		}
+		thisromname = romname; // pass rom name into global context
 		if (!file_exists(romname))
 		{
 			FILE * f=fopen(romname, "wb");
@@ -311,4 +324,3 @@ int main(int argc, char * argv[])
 	}
 	return 0;
 }
-

--- a/src/asar/interface-lib.cpp
+++ b/src/asar/interface-lib.cpp
@@ -27,6 +27,9 @@ extern const char * thisblock;
 extern const char * callerfilename;
 extern int callerline;
 
+extern const char * thisromname;
+extern const char * libdir;
+
 autoarray<const char *> prints;
 int numprint;
 
@@ -173,9 +176,24 @@ EXPORT void asar_close()
 	resetdllstuff();
 }
 
+EXPORT void asar_setromname(const char * name)
+{
+    thisromname = strdup(name);
+}
+
+EXPORT void asar_setlibdir(const char * dir)
+{
+    libdir = strdup(dir);
+}
+
 #define maxromsize (16*1024*1024)
 EXPORT bool asar_patch(const char * patchloc, char * romdata_, int buflen, int * romlen_)
 {
+	if (!libdir)
+    {
+            // default to ./lib/ (relative to rom, if specified)
+            libdir = "./lib/";
+    }
 	if (buflen!=maxromsize)
 	{
 		romdata_r=(unsigned char*)malloc(maxromsize);
@@ -348,5 +366,3 @@ EXPORT mapper_t asar_getmapper()
 {
 	return mapper;
 }
-
-

--- a/src/asar/main.cpp
+++ b/src/asar/main.cpp
@@ -32,6 +32,9 @@ const char * thisfilename;
 int thisline;
 const char * thisblock;
 
+const char * thisromname;
+const char * libdir;
+
 const char * callerfilename=NULL;
 int callerline=-1;
 


### PR DESCRIPTION
`import`: acts as an incsrc from a target-relative search directory (defaults to `./lib/`)
`undef`: explicitly deletes a define