### PR TITLE
Absolute path include / CMakeFile

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,10 @@
 cmake_minimum_required(VERSION 3.9.0)
 
+option(ASAR_GEN_TEST "Generate tests" ON)
+
 add_subdirectory(asar)
 
-add_subdirectory(asar-app-test)
-
-add_subdirectory(asar-dll-test)
+if(ASAR_GEN_TEST)
+	add_subdirectory(asar-app-test)
+	add_subdirectory(asar-dll-test)
+endif(ASAR_GEN_TEST)

--- a/src/asar/CMakeLists.txt
+++ b/src/asar/CMakeLists.txt
@@ -3,6 +3,8 @@
 
 cmake_minimum_required(VERSION 3.9.0)
 
+option(ASAR_GEN_EXE "Generate executable" ON)
+option(ASAR_GEN_DLL "Generate shared library" ON)
 
 
 
@@ -46,6 +48,16 @@ macro(set_asar_shared_properties target)
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4820")
 	else()
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic")
+
+		# Static link for MinGW
+		if(MINGW)
+			set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -static")
+		endif()
+
+		# Garbage collection
+		set(CMAKE_EXE_LINKER_FLAGS_RELEASE "-s -Wl,--gc-sections")
+		set(CMAKE_STATIC_LINKER_FLAGS_RELEASE "-T")
+		set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "-s -Wl,--gc-sections")
 	endif()
 endmacro()
 
@@ -122,16 +134,18 @@ endif()
 
 # Define stand-alone application
 
-add_executable(
-	asar-standalone
-	
-	"${CMAKE_CURRENT_SOURCE_DIR}/interface-cli.cpp"
-	
-	${ASAR_SHARED_SOURCE_FILES}	
-	${ASAR_RESOURCE_FILES}
-)
+if(ASAR_GEN_EXE)
+	add_executable(
+		asar-standalone
 
-set_asar_shared_properties(asar-standalone)
+		"${CMAKE_CURRENT_SOURCE_DIR}/interface-cli.cpp"
+
+		${ASAR_SHARED_SOURCE_FILES}	
+		${ASAR_RESOURCE_FILES}
+		)
+
+	set_asar_shared_properties(asar-standalone)
+endif(ASAR_GEN_EXE)
 
 
 
@@ -139,12 +153,14 @@ set_asar_shared_properties(asar-standalone)
 
 # Define dynamic library
 
-add_library(
-	asar SHARED	
+if(ASAR_GEN_DLL)
+	add_library(
+		asar SHARED	
+		
+		"${CMAKE_CURRENT_SOURCE_DIR}/interface-lib.cpp"
+		
+		${ASAR_SHARED_SOURCE_FILES}
+	)
 	
-	"${CMAKE_CURRENT_SOURCE_DIR}/interface-lib.cpp"
-	
-	${ASAR_SHARED_SOURCE_FILES}
-)
-
-set_asar_shared_properties(asar)
+	set_asar_shared_properties(asar)
+endif(ASAR_GEN_DLL)

--- a/src/asar/CMakeLists.txt
+++ b/src/asar/CMakeLists.txt
@@ -78,7 +78,6 @@ list(
 	"${CMAKE_CURRENT_SOURCE_DIR}/libmisc.h"
 	"${CMAKE_CURRENT_SOURCE_DIR}/libsmw.h"
 	"${CMAKE_CURRENT_SOURCE_DIR}/libstr.h"
-	"${CMAKE_CURRENT_SOURCE_DIR}/scapegoat.hpp"
 	
 	"${CMAKE_CURRENT_SOURCE_DIR}/std-includes.h"
 	"${CMAKE_CURRENT_SOURCE_DIR}/platform/file-helpers.h"

--- a/src/asar/assembleblock.cpp
+++ b/src/asar/assembleblock.cpp
@@ -1510,7 +1510,23 @@ void assembleblock(const char * block)
 #endif
 		}
 		if (emulatexkas) name=dequote(par);
-		else name=S dir(thisfilename)+dequote(par);
+		else
+		{
+			const char* path = dequote(par);
+#ifdef _WIN32
+			if( (isalpha(path[0]) && (':' == path[1]) && (('\\' == path[2]) || ('/' == path[2])))	/* drive letter + root */
+			 || ('\\' == path[0]) || ('/' == path[0]))	/* root */
+#else
+			if('/' == path[0])	/* root */
+#endif
+			{
+				name=S path;
+			}
+			else
+			{
+				name=S dir(thisfilename)+path;
+			}
+		}
 		assemblefile(name, false);
 	}
 	else if (is1("incbin") || is3("incbin"))
@@ -1549,7 +1565,23 @@ void assembleblock(const char * block)
 #endif
 		}
 		if (emulatexkas) name=dequote(par);
-		else name=S dir(thisfilename)+dequote(par);
+		else
+		{
+			const char* path = dequote(par);
+#ifdef _WIN32
+			if( (isalpha(path[0]) && (':' == path[1]) && (('\\' == path[2]) || ('/' == path[2])))	/* drive letter + root */
+			 || ('\\' == path[0]) || ('/' == path[0]))	/* root */
+#else
+			if('/' == path[0])	/* root */
+#endif
+			{
+				name=S path;
+			}
+			else
+			{
+				name=S dir(thisfilename)+path;
+			}
+		}
 		char * data;//I couldn't find a way to get this into an autoptr
 		if (!readfile(name, &data, &len)) error(0, "File not found");
 		autoptr<char*> datacopy=data;


### PR DESCRIPTION
This pull request includes the following changes.

# Absolute path include feature

I noticed that ASAR can't include with an absolute path.

Since there was a problem at the time of tool creation, I changed it so that it can be included in absolute path.

# CMakeFile options

Since it is convenient to be able to limit the target of compilation, we added the following three options.

- ASAR_GEN_TEST
- ASAR_GEN_EXE
- ASAR_GEN_DLL

In particular, I think that the test code should be excluded from compilation because it can't be built in the MinGW environment.

For every option, the default value is ON (generate code).
