### PR TITLE
Make test suite compile under linux

### DIFF
--- a/src/asar-tests-shared/test.cpp
+++ b/src/asar-tests-shared/test.cpp
@@ -33,6 +33,8 @@
 #	include <dirent.h>
 #	include <vector>
 #	include <string>
+#	include <string.h>
+#	include <sys/stat.h>
 #endif
 
 #if defined(ASAR_TEST_DLL)


### PR DESCRIPTION
You slightly changed some stuff about the tests, but you forgot to include the required headers when not on Windows. This made the Travis build fail. I fixed it.