### PR TITLE
Don't redefine strdup on macOS

### DIFF
--- a/src/asar/libstr.h
+++ b/src/asar/libstr.h
@@ -603,7 +603,7 @@ inline bool striwcmp(const char *s, const char *p) {
 }
 
 //I thought this one was FreeBSD-only, and now it suddenly exists in MSVC but not GCC?
-#if !defined(_MSC_VER)
+#if !defined(_MSC_VER) && !defined(__APPLE__)
 inline char * strdup(const char * str) throw ()
 {
 	char * a=(char*)malloc(sizeof(char)*(strlen(str)+1));


### PR DESCRIPTION
Fixes #52 