### PR TITLE
Using strcpy is defective in string::assign.

### DIFF
--- a/src/asar/libstr.h
+++ b/src/asar/libstr.h
@@ -46,7 +46,11 @@ void assign(const char * newstr)
 	if (!newstr) newstr="";
 	len=(int)strlen(newstr);
 	resize(len);
-	strcpy(str, newstr);
+    for(int i = 0; i < len; ++i)
+    {
+        str[i] = newstr[i];
+    }
+    str[len] = '\0';
 }
 
 void assign(const char * newstr, int newlen)

--- a/src/asar/libstr.h
+++ b/src/asar/libstr.h
@@ -46,11 +46,8 @@ void assign(const char * newstr)
 	if (!newstr) newstr="";
 	len=(int)strlen(newstr);
 	resize(len);
-    for(int i = 0; i < len; ++i)
-    {
-        str[i] = newstr[i];
-    }
-    str[len] = '\0';
+	memmove(str, newstr, len);
+	str[len] = '\0';
 }
 
 void assign(const char * newstr, int newlen)
@@ -58,7 +55,8 @@ void assign(const char * newstr, int newlen)
 	if (!newstr) return;
 	len=newlen;
 	resize(len);
-	memcpy(str, newstr, (size_t)len);
+	memmove(str, newstr, (size_t)len);
+	str[len] = '\0';
 	len=(int)strlen(str);
 }
 
@@ -80,8 +78,9 @@ string& operator+=(const string& newstr)
 {
 	fixlen();
 	resize(len+newstr.truelen());
-	strcpy(str+len, newstr.str);
+	memmove(str+len, newstr.str, newstr.len);
 	len+=newstr.len;
+	str[len] = '\0';
 	return *this;
 }
 
@@ -90,8 +89,9 @@ string& operator+=(const char * newstr)
 	fixlen();
 	int newlen=(int)strlen(newstr);
 	resize(len+newlen);
-	strcpy(str+len, newstr);
+	memmove(str+len, newstr, newlen);
 	len+=newlen;
+	str[len] = '\0';
 	return *this;
 }
 


### PR DESCRIPTION
Today I tried to find bugs in my code using `valgrind`. To be sure that I am the author of these bugs, I compared them with the current `master` branch, and this is the only issue I found. It's not a huge issue, but I might as well fix it. `strcpy` requires src and dest to be non-overlapping (http://en.cppreference.com/w/cpp/string/byte/strcpy).

This is the case in `interface-cli.cpp:250`,`interface-cli.cpp:251`,`interface-cli.cpp:267`, and `interface-cli.cpp:268`.