### PR TITLE
New optional warning and bugfix

### DIFF
--- a/src/asar/arch-65816.cpp
+++ b/src/asar/arch-65816.cpp
@@ -32,9 +32,10 @@ bool asblock_65816(char** word, int numwords)
 	unsigned int num;
 	int len=0;//declared here for A->generic fallback
 	bool explicitlen = false;
+	bool hexconstant = false;
 	if(0);
 	else if (assemblemapper(word, numwords)) {}
-#define getvars(optbank) num=(pass!=0)?getnum(par):0; if (word[0][3]=='.') { len=getlenfromchar(word[0][4]); explicitlen=true; word[0][3]='\0'; } else {len=getlen(par, optbank); explicitlen=false;}
+#define getvars(optbank) num=(pass!=0)?getnum(par):0; hexconstant=is_hex_constant(par); if (word[0][3]=='.') { len=getlenfromchar(word[0][4]); explicitlen=true; word[0][3]='\0'; } else {len=getlen(par, optbank); explicitlen=false;}
 #define match(left, right) (word[1] && stribegin(par, left) && striend(par, right))
 #define init(left, right) itrim(par, left, right); getvars(false)
 #define bankoptinit(left, right) itrim(par, left, right); getvars(true)
@@ -47,9 +48,9 @@ bool asblock_65816(char** word, int numwords)
 #define as3(    op, byte) if (is(op) && len==3) { write1((unsigned int)byte); write3(num); return true; }
 //#define as23(   op, byte) if (is(op) && (len==2 || len==3)) { write1(byte); write2(num); return true; }
 #define as32(   op, byte) if (is(op) && ((len==2 && !explicitlen) || len==3)) { write1((unsigned int)byte); write3(num); return true; }
-#define as_a(   op, byte) if (is(op)) { if(!explicitlen && warnimpimmed) warn0("implicitly sized immediate"); if (len==1) { write1(byte); write1(num); } \
+#define as_a(   op, byte) if (is(op)) { if(!explicitlen && !hexconstant && warnimpimmed) warn0("implicitly sized immediate"); if (len==1) { write1(byte); write1(num); } \
 																					 else { write1((unsigned int)byte); write2(num); } return true; }
-#define as_xy(  op, byte) if (is(op)) { if(!explicitlen && warnimpimmed) warn0("implicitly sized immediate"); if (len==1) { write1(byte); write1(num); } \
+#define as_xy(  op, byte) if (is(op)) { if(!explicitlen && !hexconstant && warnimpimmed) warn0("implicitly sized immediate"); if (len==1) { write1(byte); write1(num); } \
 																					 else {  write1((unsigned int)byte); write2(num); } return true; }
 #define as_rep( op, byte) if (is(op)) { if (pass==0) num=getnum(par); for (unsigned int i=0;i<num;i++) { write1((unsigned int)byte); } return true; }
 #define as_rel1(op, byte) if (is(op)) { int pos=(!foundlabel)?(int)num:(int)num-((snespos&0xFFFFFF)+2); write1((unsigned int)byte); write1((unsigned int)pos); \

--- a/src/asar/arch-65816.cpp
+++ b/src/asar/arch-65816.cpp
@@ -46,7 +46,7 @@ bool asblock_65816(char** word, int numwords)
 													/*if (is(op) && len==3 && emulate) { write1(byte); write2(num); return true; }*/
 #define as3(    op, byte) if (is(op) && len==3) { write1((unsigned int)byte); write3(num); return true; }
 //#define as23(   op, byte) if (is(op) && (len==2 || len==3)) { write1(byte); write2(num); return true; }
-#define as32(   op, byte) if (is(op) && (len==2 || len==3)) { write1((unsigned int)byte); write3(num); return true; }
+#define as32(   op, byte) if (is(op) && ((len==2 && !explicitlen) || len==3)) { write1((unsigned int)byte); write3(num); return true; }
 #define as_a(   op, byte) if (is(op)) { if(!explicitlen && warnimpimmed) warn0("implicitly sized immediate"); if (len==1) { write1(byte); write1(num); } \
 																					 else { write1((unsigned int)byte); write2(num); } return true; }
 #define as_xy(  op, byte) if (is(op)) { if(!explicitlen && warnimpimmed) warn0("implicitly sized immediate"); if (len==1) { write1(byte); write1(num); } \

--- a/src/asar/arch-65816.cpp
+++ b/src/asar/arch-65816.cpp
@@ -14,6 +14,7 @@ void asend_65816()
 extern int optimizeforbank;
 extern bool fastrom;
 extern bool emulatexkas;
+extern bool warnimpimmed;
 
 bool asblock_65816(char** word, int numwords)
 {
@@ -30,13 +31,14 @@ bool asblock_65816(char** word, int numwords)
 	autoptr<char*> parptr=par;
 	unsigned int num;
 	int len=0;//declared here for A->generic fallback
+	bool explicitlen = false;
 	if(0);
 	else if (assemblemapper(word, numwords)) {}
-#define getvars(optbank) num=(pass!=0)?getnum(par):0; if (word[0][3]=='.') { len=getlenfromchar(word[0][4]); word[0][3]='\0'; } else len=getlen(par, optbank)
+#define getvars(optbank) num=(pass!=0)?getnum(par):0; if (word[0][3]=='.') { len=getlenfromchar(word[0][4]); explicitlen=true; word[0][3]='\0'; } else {len=getlen(par, optbank); explicitlen=false;}
 #define match(left, right) (word[1] && stribegin(par, left) && striend(par, right))
 #define init(left, right) itrim(par, left, right); getvars(false)
 #define bankoptinit(left, right) itrim(par, left, right); getvars(true)
-#define blankinit() len=1; num=0
+#define blankinit() len=1; explicitlen=false; num=0
 #define end() return false
 #define as0(    op, byte) if (is(op)          ) { write1((unsigned int)byte);              return true; }
 #define as1(    op, byte) if (is(op) && len==1) { write1((unsigned int)byte); write1(num); return true; }
@@ -45,9 +47,9 @@ bool asblock_65816(char** word, int numwords)
 #define as3(    op, byte) if (is(op) && len==3) { write1((unsigned int)byte); write3(num); return true; }
 //#define as23(   op, byte) if (is(op) && (len==2 || len==3)) { write1(byte); write2(num); return true; }
 #define as32(   op, byte) if (is(op) && (len==2 || len==3)) { write1((unsigned int)byte); write3(num); return true; }
-#define as_a(   op, byte) if (is(op)) { if (len==1) { write1((unsigned int)byte); write1(num); } \
+#define as_a(   op, byte) if (is(op)) { if(!explicitlen && warnimpimmed) warn0("implicitly sized immediate"); if (len==1) { write1(byte); write1(num); } \
 																					 else { write1((unsigned int)byte); write2(num); } return true; }
-#define as_xy(  op, byte) if (is(op)) { if (len==1) { write1((unsigned int)byte); write1(num); } \
+#define as_xy(  op, byte) if (is(op)) { if(!explicitlen && warnimpimmed) warn0("implicitly sized immediate"); if (len==1) { write1(byte); write1(num); } \
 																					 else {  write1((unsigned int)byte); write2(num); } return true; }
 #define as_rep( op, byte) if (is(op)) { if (pass==0) num=getnum(par); for (unsigned int i=0;i<num;i++) { write1((unsigned int)byte); } return true; }
 #define as_rel1(op, byte) if (is(op)) { int pos=(!foundlabel)?(int)num:(int)num-((snespos&0xFFFFFF)+2); write1((unsigned int)byte); write1((unsigned int)pos); \

--- a/src/asar/asar.h
+++ b/src/asar/asar.h
@@ -89,6 +89,7 @@ extern int bytes;
 int getlen(const char * str, bool optimizebankextraction=false);
 unsigned int getnum(const char * str);
 double getnumdouble(const char * str);
+bool is_hex_constant(const char * str);
 
 int getlenfromchar(char c);
 

--- a/src/asar/assembleblock.cpp
+++ b/src/asar/assembleblock.cpp
@@ -607,6 +607,7 @@ extern bool math_pri;
 extern bool math_round;
 
 bool warnxkas;
+bool warnimpimmed;
 
 extern assocarr<string> defines;
 extern assocarr<string> clidefines;
@@ -670,6 +671,7 @@ void initstuff()
 	if (arch==arch_superfx) asinit_superfx();
 
 	warnxkas=false;
+	warnimpimmed=false;
 	emulatexkas=false;
 	disable_bank_cross_errors = false;
 	nested_namespaces = false;
@@ -1997,6 +1999,9 @@ void assembleblock(const char * block)
 		else if (!stricmp(word[1], "xkas")) {
 			warn0("xkas support is being deprecated and will be removed in a future version of Asar. Please use an older version of Asar (<=1.50) if you need it.");
 			warnxkas=val;
+		}
+		else if (!stricmp(word[1], "immed")) {
+			warnimpimmed=val;
 		}
 		else if (!stricmp(word[1], "bankcross")) {
 			disable_bank_cross_errors = !val;

--- a/src/asar/assembleblock.cpp
+++ b/src/asar/assembleblock.cpp
@@ -2000,7 +2000,7 @@ void assembleblock(const char * block)
 			warn0("xkas support is being deprecated and will be removed in a future version of Asar. Please use an older version of Asar (<=1.50) if you need it.");
 			warnxkas=val;
 		}
-		else if (!stricmp(word[1], "immed")) {
+		else if (!stricmp(word[1], "immediate")) {
 			warnimpimmed=val;
 		}
 		else if (!stricmp(word[1], "bankcross")) {

--- a/src/asar/main.cpp
+++ b/src/asar/main.cpp
@@ -164,6 +164,20 @@ static int getlenforlabel(int insnespos, int thislabel, bool exists)
 
 string posneglabelname(const char ** input, bool define);
 
+bool is_hex_constant(const char* str){
+	if (*str=='$')
+	{
+		str++;
+		while(isxdigit(*str)) {
+			str++;
+		}
+		if(*str=='\0'){
+			return true;
+		}
+	}
+	return false;
+}
+
 int getlen(const char * orgstr, bool optimizebankextraction)
 {
 	const char * str=orgstr;


### PR DESCRIPTION
It should be possible to completely avoid having asar silently create non-working code due to assumptions. Using `bank noassume` brings us most of the way there. But immediate mode instructions can still be incorrectly assembled if the user fails to specify `.b` or `.w`. Asar's heuristics are pretty good and usually get things right, especially if the value is a hexadecimal constant. However, it can guess wrong on occasion, especially in cases involving calculations.

To allow detecting these I've added a new optional warning that can be enabled with "warn immed on", that warns if an immediate instruction has implicit size and is therefore relying on the heuristics for correctness. If size is explicitly specified with `.b` or .`w`, the warning is obviously not generated.

This also let me fix the following (from the 1.5.0 manual.txt's Known Bugs section):
>JML.w and JSL.w aren't rejected; they're treated as JML.l and JSL.l. This is since Asar has a much
  more powerful size finding system than xkas, and automatically picks .w if it contains a label in
  the same bank - even for .l-only instructions like JML. Therefore, I'm forced to either reject JML
  and JSL to a label in the same bank, or allow JML.w, and I prefer allowing unusual but bad stuff
  over rejecting common and valid stuff. Workaround: Don't do this.

This was fixed by emit an error only if a size of .w is explicitly specified, while permitting a calculated size of .w to be used without error.
