### PR TITLE
Make filesize() error when the file doesn't exist

### DIFF
--- a/src/asar/math.cpp
+++ b/src/asar/math.cpp
@@ -399,7 +399,7 @@ static double filesizefunc(const funcparam& fname)
 {
 	validateparam(fname, 0, Type_String);
 	cachedfile * fhandle = opencachedfile(fname.value.stringvalue, false);
-	if (fhandle == nullptr || fhandle->filehandle == INVALID_VIRTUAL_FILE_HANDLE) return -1;
+	if (fhandle == nullptr || fhandle->filehandle == INVALID_VIRTUAL_FILE_HANDLE) error("File does not exist.");
 	return (double)fhandle->filesize;
 }
 


### PR DESCRIPTION
Closes #79.