### PR TITLE
Allow string argument passthrough

### DIFF
--- a/tests/functest3.asm
+++ b/tests/functest3.asm
@@ -1,0 +1,8 @@
+;@03
+
+function test(abc,ab) = abc+ab
+
+org $8000
+
+main:
+	db test(1,2)

--- a/tests/v160features.asm
+++ b/tests/v160features.asm
@@ -14,6 +14,8 @@
 ;@01 90 02
 ;@00 80 00
 ;@01 90 02
+;@8a
+;@ac
 
 @asar 1.60
 
@@ -24,7 +26,7 @@ org $008000
 base $029001
 
 BaseTest1:
-	
+
 pushbase
 
 base off
@@ -34,7 +36,7 @@ BaseTest2:
 pullbase
 
 BaseTest3:
-	
+
 base off
 
 
@@ -78,3 +80,7 @@ dl BaseTest1
 dl BaseTest2
 dl BaseTest3
 
+function readfile1_incremented(filename, pos) = readfile1(filename, pos)+1
+
+db readfile1_incremented("data/64kb.bin",0)
+db readfile1_incremented("data/64kb.bin",1)


### PR DESCRIPTION
Fixes #56 without changing the syntax.
The following code (based on the example in that bug) will simply work with this patch.
```
function readfilenormalized(filename, pos) = readfile1(filename, pos)/255
```
The approach is simply checking to see if a function argument is one of the parameters of the user function currently being executed. If it is pass it directly through to function being called. 

This also fixes #86, which I found while coding this. (The fix is the same as was previously used for a similar issue matching the names of the built in functions).