### PR TITLE
Allow overriding checksum generation

### DIFF
--- a/src/asar-dll-bindings/c/asardll.h
+++ b/src/asar-dll-bindings/c/asardll.h
@@ -98,6 +98,11 @@ struct patchparams
 	// Specify warnings in the format "WXXXX" where XXXX = warning ID.
 	const struct warnsetting * warning_settings;
 	int warning_setting_count;
+
+	// Set override_checksum_gen to true and generate_checksum to true/false
+	// to force generating/not generating a checksum.
+	bool override_checksum_gen;
+	bool generate_checksum;
 };
 
 #endif

--- a/src/asar/asar.h
+++ b/src/asar/asar.h
@@ -74,6 +74,7 @@ extern bool istoplevel;
 extern bool moreonline;
 
 extern bool checksum_fix_enabled;
+extern bool force_checksum_fix;
 
 extern const char * callerfilename;
 extern int callerline;

--- a/src/asar/assembleblock.cpp
+++ b/src/asar/assembleblock.cpp
@@ -1115,7 +1115,8 @@ void assembleblock(const char * block)
 		asar_throw_warning(0, warning_id_xkas_deprecated);
 		emulatexkas=true;
 		optimizeforbank=0x100;
-		checksum_fix_enabled =false;
+		if(!force_checksum_fix)
+			checksum_fix_enabled = false;
 		sublabels[0]=":xkasdefault:";
 	}
 	else if (is0("include") || is1("includefrom"))
@@ -1939,7 +1940,13 @@ void assembleblock(const char * block)
 		if (!stricmp(par, "65816")) { arch=arch_65816; return; }
 		if (!stricmp(par, "spc700")) { arch=arch_spc700; return; }
 		if (!stricmp(par, "spc700-inline")) { arch=arch_spc700_inline; return; }
-		if (!stricmp(par, "spc700-raw")) { arch=arch_spc700; mapper=norom; checksum_fix_enabled =false; return; }
+		if (!stricmp(par, "spc700-raw")) {
+			arch=arch_spc700;
+			mapper=norom;
+			if(!force_checksum_fix)
+				checksum_fix_enabled = false;
+			return;
+		}
 		if (!stricmp(par, "superfx")) { arch=arch_superfx; return; }
 	}
 	else if (is2("math"))
@@ -2020,7 +2027,8 @@ bool assemblemapper(char** word, int numwords)
 		//$000000 would be the best snespos for this, but I don't care
 		mapper=norom;
 		//fastrom=false;
-		checksum_fix_enabled =false;//we don't know where the header is, so don't set the checksum
+		if(!force_checksum_fix)
+			checksum_fix_enabled = false;//we don't know where the header is, so don't set the checksum
 	}
 	else if (is0("fullsa1rom"))
 	{

--- a/src/asar/interface-cli.cpp
+++ b/src/asar/interface-cli.cpp
@@ -139,10 +139,12 @@ int main(int argc, char * argv[])
 			" --symbols-path=<filename>\n"
 			"                   Override the default path to the symbols output file. The default is the ROM's base name with an\n"
 			"                   extension of '.sym'.\n\n"
-			" --no-title-check  \n"
-			"                   Disable verifying ROM title. (Note that irresponsible use will likely corrupt your ROM)\n"
-			" --pause-mode=<never/on-error/on-warning/always>\n\n"
-			"                   Specify when Asar should pause the application. (Never, on error, on warning or always)\n"
+			" --no-title-check\n"
+			"                   Disable verifying ROM title. (Note that irresponsible use will likely corrupt your ROM)\n\n"
+			" --pause-mode=<never/on-error/on-warning/always>\n"
+			"                   Specify when Asar should pause the application. (Never, on error, on warning or always)\n\n"
+			" --fix-checksum=<on/off>\n"
+			"                   Override Asar's checksum generation, allowing you to manually enable/disable generating a checksum\n\n"
 			" -I<path>          \n"
 			" --include <path>  \n"
 			"                   Add an include search path to Asar.\n\n"
@@ -203,6 +205,15 @@ int main(int argc, char * argv[])
 				else if (par=="--pause-mode=on-warning") pause=pause_warn;
 				else if (par=="--pause-mode=always") pause=pause_yes;
 				else libcon_badusage();
+			}
+			else if(checkstartmatch(par, "--fix-checksum=")) {
+				if(par=="--fix-checksum=on") {
+					force_checksum_fix = true;
+					checksum_fix_enabled = true;
+				} else if(par=="--fix-checksum=off") {
+					force_checksum_fix = true;
+					checksum_fix_enabled = false;
+				} else libcon_badusage();
 			}
 			else if (checkstartmatch(par, "-I"))
 			{

--- a/src/asar/interface-lib.cpp
+++ b/src/asar/interface-lib.cpp
@@ -164,6 +164,9 @@ struct patchparams_v160 : public patchparams_base
 
 	const warnsetting * warning_settings;
 	int warning_setting_count;
+
+	bool override_checksum_gen;
+	bool generate_checksum;
 };
 
 struct patchparams : public patchparams_v160
@@ -354,6 +357,11 @@ EXPORT bool asar_patch_ex(const patchparams_base* params)
 		{
 			asar_throw_error(pass, error_type_null, error_id_invalid_warning_id, "asar_patch_ex() warning_settings", (int)(warning_id_start + 1), (int)(warning_id_end - 1));
 		}
+	}
+
+	if(paramscurrent.override_checksum_gen) {
+		checksum_fix_enabled = paramscurrent.generate_checksum;
+		force_checksum_fix = true;
 	}
 
 	asar_patch_main(paramscurrent.patchloc);

--- a/src/asar/main.cpp
+++ b/src/asar/main.cpp
@@ -752,7 +752,8 @@ void parse_std_defines(const char* textfile)
 	builtindefines.create("assembler_ver") = get_version_int();
 }
 
-bool checksum_fix_enabled =true;
+bool checksum_fix_enabled = true;
+bool force_checksum_fix = false;
 
 #define cfree(x) free((void*)x)
 static void clearmacro(const string & key, macrodata* & macro)
@@ -835,6 +836,7 @@ void reseteverything()
 	incsrcdepth=0;
 	errored = false;
 	checksum_fix_enabled = true;
+	force_checksum_fix = false;
 	
 	lastspecialline = -1;
 #undef free


### PR DESCRIPTION
Closes #90.
This time I implemented this as a command line flag and a `patchparams` member.