### PR TITLE
Fix the C# wrapper

### DIFF
--- a/src/asar-dll-bindings/c_sharp/asar.cs
+++ b/src/asar-dll-bindings/c_sharp/asar.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Linq;
 
 namespace AsarCLR
 {


### PR DESCRIPTION
Turns out it was just a missing `using` directive.