### PR TITLE
[MinGW]Fix for cross-build 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: cpp
+sudo: false
 compiler:
   - clang
   - gcc
@@ -27,3 +28,29 @@ addons:
   apt:
     packages:
       - lcov
+
+# MinGW cross-builds (make only)
+matrix:
+  include:
+    - os: linux
+      compiler: i686-w64-mingw32-gcc
+      addons:
+        apt:
+          packages:
+            - binutils-mingw-w64-i686
+            - gcc-mingw-w64-i686
+            - g++-mingw-w64-i686
+      script:
+        - cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE=../cmake/mingw-x86.cmake $CMAKE_EXTRA_OPTS ../src
+        - make
+    - os: linux
+      compiler: x86_64-w64-mingw32-gcc
+      addons:
+        apt:
+          packages:
+            - binutils-mingw-w64-x86-64
+            - gcc-mingw-w64-x86-64
+            - g++-mingw-w64-x86-64
+      script:
+        - cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE=../cmake/mingw-x64.cmake $CMAKE_EXTRA_OPTS ../src
+        - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ os:
 before_install:
   # pip is annoying on osx and the coverage tool can't parse clang's output, so only run it on linux gcc
   - if [ $TRAVIS_OS_NAME == linux -a $CC == gcc ]; then GEN_COVERAGE=1; fi
-  - if [ $GEN_COVERAGE ]; then pip install --user cpp-coveralls; CMAKE_EXTRA_OPTS="-DASAR_COVERAGE=ON"; fi
+  - if [ $TRAVIS_OS_NAME == linux -a $COMPILER == i686-w64-mingw32-gcc ]; then GEN_COVERAGE=1 CMAKE_EXTRA_OPTS="-DCMAKE_TOOLCHAIN_FILE=../cmake/mingw-x86.cmake"; fi
+  - if [ $TRAVIS_OS_NAME == linux -a $COMPILER == x86_64-w64-mingw32-gcc ]; then GEN_COVERAGE=1 CMAKE_EXTRA_OPTS="-DCMAKE_TOOLCHAIN_FILE=../cmake/mingw-x64.cmake"; fi
+  - if [ $GEN_COVERAGE ]; then pip install --user cpp-coveralls; CMAKE_EXTRA_OPTS="$CMAKE_EXTRA_OPTS -DASAR_COVERAGE=ON"; fi
 install: # misc setup that I didn't want to put in script
   - mkdir build tests_dll_tmp tests_app_tmp
   - cd build
@@ -18,9 +20,9 @@ script:
   - make
   # run dll test suite
   # We need to pass the DLL path as an absolute path because it is used to calculate the std defines location, which will throw a warning when it's a relative path
-  - asar-tests/asar-dll-test $TRAVIS_BUILD_DIR/build/asar/libasar.* $TRAVIS_BUILD_DIR/tests ../dummy_rom.sfc $TRAVIS_BUILD_DIR/tests_dll_tmp
+  - asar-tests/asar-dll-test$EXE_SUFFIX $TRAVIS_BUILD_DIR/build/asar/libasar.* $TRAVIS_BUILD_DIR/tests ../dummy_rom.sfc $TRAVIS_BUILD_DIR/tests_dll_tmp
   # run app test suite
-  - asar-tests/asar-app-test asar/asar-standalone $TRAVIS_BUILD_DIR/tests ../dummy_rom.sfc $TRAVIS_BUILD_DIR/tests_app_tmp
+  - asar-tests/asar-app-test$EXE_SUFFIX asar/asar-standalone $TRAVIS_BUILD_DIR/tests ../dummy_rom.sfc $TRAVIS_BUILD_DIR/tests_app_tmp
 after_success:
   - cd ..
   - if [ $GEN_COVERAGE ]; then lcov -c -d build -o coverage.info; coveralls --verbose --include src/asar --lcov-file coverage.info; fi
@@ -34,23 +36,29 @@ matrix:
   include:
     - os: linux
       compiler: i686-w64-mingw32-gcc
+      sudo: true # Wine requires a lot of disk spaces. Therefore, use "Ubuntu Trusty VM" environment.
+      env:
+        - COMPILER=i686-w64-mingw32-gcc # $CC will overwritten by Travis.
+        - EXE_SUFFIX=.exe
       addons:
         apt:
           packages:
             - binutils-mingw-w64-i686
             - gcc-mingw-w64-i686
             - g++-mingw-w64-i686
-      script:
-        - cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE=../cmake/mingw-x86.cmake $CMAKE_EXTRA_OPTS ../src
-        - make
+            - lcov
+            - wine
     - os: linux
       compiler: x86_64-w64-mingw32-gcc
+      sudo: true # Wine requires a lot of disk spaces. Therefore, use "Ubuntu Trusty VM" environment.
+      env:
+        - COMPILER=x86_64-w64-mingw32-gcc # $CC will overwritten by Travis.
+        - EXE_SUFFIX=.exe
       addons:
         apt:
           packages:
             - binutils-mingw-w64-x86-64
             - gcc-mingw-w64-x86-64
             - g++-mingw-w64-x86-64
-      script:
-        - cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE=../cmake/mingw-x64.cmake $CMAKE_EXTRA_OPTS ../src
-        - make
+            - lcov
+            - wine

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ compiler:
 os:
   - linux
   - osx
+cache:
+  directories:
+    - $HOME/.cache/pip
+before_cache:
+  - rm -f $HOME/.cache/pip/log/debug.log
 before_install:
   # pip is annoying on osx and the coverage tool can't parse clang's output, so only run it on linux gcc
   - if [ $TRAVIS_OS_NAME == linux -a $CC == gcc ]; then GEN_COVERAGE=1; fi

--- a/cmake/_mingw-common.cmake
+++ b/cmake/_mingw-common.cmake
@@ -1,0 +1,28 @@
+#-----------------------------------------------------------
+# mingw toolchain common
+#-----------------------------------------------------------
+
+set(MINGW ON)
+set(WIN32 ON)
+set(CMAKE_SYSTEM_NAME Windows)
+set(TOOL_PREFIX "${MINGW_TYPE}-")
+
+if(CLANG)
+        set(CMAKE_C_COMPILER "${TOOL_PREFIX}clang")
+        set(CMAKE_CXX_COMPILER "${TOOL_PREFIX}clang++")
+else(CLANG)
+        set(CMAKE_C_COMPILER "${TOOL_PREFIX}gcc")
+        set(CMAKE_CXX_COMPILER "${TOOL_PREFIX}g++")
+endif(CLANG)
+
+set(CMAKE_RC_COMPILER ${TOOL_PREFIX}windres)
+set(CMAKE_RC_COMPILE_OBJECT 
+	"<CMAKE_RC_COMPILER> <FLAGS> -O coff <DEFINES> -i <SOURCES> -o <OBJECT>")
+#set(CMAKE_LINKER "${TOOL_PREFIX}g++")
+#set(CMAKE_AR "${TOOL_PREFIX}ar")
+
+set(CMAKE_FIND_ROOT_PATH "/usr/${MINGW_TYPE}/")
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+

--- a/cmake/mingw-x64.cmake
+++ b/cmake/mingw-x64.cmake
@@ -1,0 +1,5 @@
+#-----------------------------------------------------------
+# mingw x64 toolchain
+#-----------------------------------------------------------
+set(MINGW_TYPE "x86_64-w64-mingw32")
+include(${CMAKE_CURRENT_LIST_DIR}/_mingw-common.cmake)

--- a/cmake/mingw-x86.cmake
+++ b/cmake/mingw-x86.cmake
@@ -1,0 +1,5 @@
+#-----------------------------------------------------------
+# mingw x86 toolchain
+#-----------------------------------------------------------
+set(MINGW_TYPE "i686-w64-mingw32")
+include(${CMAKE_CURRENT_LIST_DIR}/_mingw-common.cmake)

--- a/src/asar-dll-bindings/c/asardll.c
+++ b/src/asar-dll-bindings/c/asardll.c
@@ -8,7 +8,7 @@
 #		pragma warning(disable : 4668)
 #	endif
 
-#	include <Windows.h>
+#	include <windows.h>
 
 #	if defined(_MSC_VER)
 #		pragma warning(pop)

--- a/src/asar-tests/test.cpp
+++ b/src/asar-tests/test.cpp
@@ -22,7 +22,7 @@
 #	include <string.h>
 #	include <stdlib.h>
 #	include <sys/stat.h>
-#	include <Windows.h>
+#	include <windows.h>
 #	include <vector>
 #	include <string>
 #	include <algorithm>

--- a/src/asar/platform/windows/file-helpers-win32.cpp
+++ b/src/asar/platform/windows/file-helpers-win32.cpp
@@ -8,7 +8,7 @@
 #	pragma warning(disable : 4987)
 #endif
 
-#include <Windows.h>
+#include <windows.h>
 #include <ctype.h>
 
 #if defined(_MSC_VER)


### PR DESCRIPTION
# Summary

A compile error occurred when cross-building, so I fixed it.

## Changes

- Changed the include file name (**W**indows.h to **w**indows.h)
- Added settings and cmake files for travis.ci