### PR TITLE
fix labels starting with underscores

### DIFF
--- a/src/asar/main.cpp
+++ b/src/asar/main.cpp
@@ -249,7 +249,7 @@ notposneglabel:
 			if (val>=65536) thislen=3;
 			if (val>=16777216) thislen=4;
 		}
-		else if (isalpha(*str) || *str=='.' || *str=='?')
+		else if (isalpha(*str) || *str=='_' || *str=='.' || *str=='?')
 		{
 			unsigned int thislabel;
 			bool exists=labelval(&str, &thislabel);


### PR DESCRIPTION
fixes niche bug involving labels starting with underscores. the following now assembles:
```
_0: jmp _0
```