### PR TITLE
bindings: Fix strict aliasing issues on Windows

### DIFF
--- a/src/asar-dll-bindings/c/asardll.c
+++ b/src/asar-dll-bindings/c/asardll.c
@@ -1,5 +1,5 @@
-
-#define NULL 0
+#include <stdbool.h>
+#include <stddef.h>
 
 #if defined(_WIN32)
 #	if defined(_MSC_VER)
@@ -63,7 +63,12 @@ inline static void * getlibfrompath(const char * path)
 	return ret_val;
 }
 
-#	define loadraw(name, target) *((int(**)(void))&target)=(int(*)(void))GetProcAddress((HINSTANCE)asardll, name); require(target)
+inline static bool setfunction(void* target, FARPROC fn)
+{
+	memcpy(target, &fn, sizeof(fn));
+	return fn;
+}
+#	define loadraw(name, target) require(setfunction(&target, GetProcAddress((HINSTANCE)asardll, name)))
 #	define closelib(var) FreeLibrary((HINSTANCE)var)
 #else
 #	include <dlfcn.h>
@@ -102,7 +107,7 @@ inline static void * getlibfrompath(const char * path)
 #endif
 
 #include "asardll.h"
-	
+
 #undef asarfunc
 #undef ASAR_DLL_H_INCLUDED
 


### PR DESCRIPTION
```
$ wine gcc -O3 -Wall asardll.c
asardll.c: In function 'asar_init_shared':
asardll.c:66:34: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
 # define loadraw(name, target) *((int(**)(void))&target)=(int(*)(void))GetProcAddress((HINSTANCE)asardll, name); require(target)
                                 ~^~~~~~~~~~~~~~~~~~~~~~~
asardll.c:118:21: note: in expansion of macro 'loadraw'
 #define loadi(name) loadraw("asar_"#name, asar_i_##name)
                     ^~~~~~~
asardll.c:123:2: note: in expansion of macro 'loadi'
  loadi(init);
  ^~~~~
[repeat about 20 times]
```

also I think defining your own NULL is undefined behavior, better leave it to libc.