### PR TITLE
don't sign-extend character array indices

### DIFF
--- a/src/asar/assembleblock.cpp
+++ b/src/asar/assembleblock.cpp
@@ -1252,10 +1252,10 @@ void assembleblock(const char * block)
 					asar_throw_warning(0, warning_id_xkas_patch);
 				for (char * str=const_cast<char*>(safedequote(pars[i]));*str;str++)
 				{
-					if (len==1) write1(table.table[(size_t)*str]);
-					if (len==2) write2(table.table[(size_t)*str]);
-					if (len==3) write3(table.table[(size_t)*str]);
-					if (len==4) write4(table.table[(size_t)*str]);
+					if (len==1) write1(table.table[(size_t)(unsigned char) *str]);
+					if (len==2) write2(table.table[(size_t)(unsigned char) *str]);
+					if (len==3) write3(table.table[(size_t)(unsigned char) *str]);
+					if (len==4) write4(table.table[(size_t)(unsigned char) *str]);
 				}
 			}
 			else


### PR DESCRIPTION
When `char` is signed, casting characters 0x80...0xff to `size_t` will produce huge indices (e.g. 0x80 -> 0xffffff80) which will usually lead to undefined behavior here. Observed result is that Asar generates nonsense when fed "negative" characters in a string literal. Casting through `unsigned char` avoids this.

I have avoided touching the `const_cast` here because it doesn't seem to be necessary but seems to have been added to please a compiler.