### PR TITLE
Fixed documentation highlighting issues

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "/usr/bin/python3"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/usr/bin/python3"
+}

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -1763,11 +1763,11 @@ warnpc $008100		; Throws an error if datafile.bin is larger than $100 bytes.</co
 		The bank command makes Asar's label optimizer act as though the current data bank was set to <code>data_bank</code>. Consider the following example:		
 		<pre><code class="65c816_asar">bank $FF
 		
-lda Table,x
+lda DataTable,x
 
-Table:
+DataTable:
 	db $01,$02,$03,$04</code></pre>
-		Asar will always assemble the <code class="65c816_asar">lda Table,x</code> with 24-bit addressing, unless the current pc (or <a href="#base">base address</a>) is inside bank <code>$FF</code> itself. This is intended for code that uses a data bank register different from the code bank register. You can use <code>bank noassume</code> to make Asar act as though the data bank was always in a different bank. Using <code>bank auto</code> restores the default behavior of assuming that the data bank register and the code bank register are the same. Note that the bank command can't point to freespace areas.		
+		Asar will always assemble the <code class="65c816_asar">lda DataTable,x</code> with 24-bit addressing, unless the current pc (or <a href="#base">base address</a>) is inside bank <code>$FF</code> itself. This is intended for code that uses a data bank register different from the code bank register. You can use <code>bank noassume</code> to make Asar act as though the data bank was always in a different bank. Using <code>bank auto</code> restores the default behavior of assuming that the data bank register and the code bank register are the same. Note that the bank command can't point to freespace areas.		
 		<pre><code class="65c816_asar">org $008000
 phb
 lda #$FF
@@ -2804,7 +2804,7 @@ dl $01,$0203,$04050607,Label,"ABC"
 ; $01 $00 $00 $00  $03 $02 $00 $00  $07 $06 $05 $04  $AB $89 $01 $00  $41 $00 $00 $00 $42 $00 $00 $00 $43 $00 $00 $00
 dd $01,$0203,$04050607,Label,"ABC"</code></pre>
 		By default, each character in an ASCII string used in in a table maps onto the respective ASCII value. This mapping can be customized via the table command:
-		<pre><code class="65c816_asar">table {filename}[,ltr/rtl]</code></pre>
+		<pre><code class="65c816_asar">table {filename}[,rtl/ltr]</code></pre>
 		Where <code>filename</code> specifies the path to a table file (enclose in double quotes to use file names with spaces, see section <a href="#includes">Includes</a> for details on Asar's handling of file names) and ltr/rtl specifies whether that file is in left-to-right or right-to left format (default: left-to-right).<br />
 		Format of left-to-right table files:
 		<pre><code>{character}={value}

--- a/docs/shared/highlight_js/highlight.pack.js
+++ b/docs/shared/highlight_js/highlight.pack.js
@@ -14,7 +14,7 @@ hljs.registerLanguage("powershell", function(e) {
 // I know this is ugly, but I don't know how else to solve Asar's label rules...
 var asar_opcodes = ["db", "dw", "dl", "dd", "adc", "and", "asl", "bcc", "blt", "bcs", "bge", "beq", "bit", "bmi", "bne", "bpl", "bra", "brk", "brl", "bvc", "bvs", "clc", "cld", "cli", "clv", "cmp", "cop", "cpx", "cpy", "dec", "dea", "dex", "dey", "eor", "inc", "ina", "inx", "iny", "jmp", "jml", "jsr", "jsl", "lda", "ldx", "ldy", "lsr", "mvn", "mvp", "nop", "ora", "pea", "pei", "per", "pha", "phb", "phd", "phk", "php", "phx", "phy", "pla", "plb", "pld", "plp", "plx", "ply", "rep", "rol", "ror", "rti", "rtl", "rts", "sbc", "sec", "sed", "sei", "sep", "sta", "stp", "stx", "sty", "stz", "tax", "tay", "tcd", "tcs", "tdc", "trb", "tsc", "tsb", "tsx", "txa", "txs", "txy", "tya", "tyx", "wai", "wdm", "xba", "xce", "r0", "r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15", "add", "alt1", "alt2", "alt3", "asr", "bic", "cache", "cmode", "color", "div2", "fmult", "from", "getb", "getbh", "getbl", "getbs", "getc", "hib", "ibt", "iwt", "ldb", "ldw", "link", "ljmp", "lm", "lms", "lmult", "lob", "loop", "merge", "mult", "not", "or", "plot", "ramb", "romb", "rpix", "sbk", "sex", "sm", "sms", "stb", "stop", "stw", "sub", "swap", "to", "umult", "with", "xor", "addw", "ya", "and1", "bbc0", "bbc1", "bbc2", "bbc3", "bbc4", "bbc5", "bbc6", "bbc7", "bbs0", "bbs1", "bbs2", "bbs3", "bbs4", "bbs5", "bbs6", "bbs7", "call", "cbne", "clr0", "clr1", "clr2", "clr3", "clr4", "clr5", "clr6", "clr7", "clrc", "clrp", "clrv", "cmpw", "daa", "das", "dbnz", "decw", "di", "div", "ei", "eor1", "incw", "mov", "sp", "mov1", "movw", "mul", "not1", "notc", "or1", "pcall", "pop", "push", "ret", "reti", "set0", "set1", "set2", "set3", "set4", "set5", "set6", "set7", "setc", "setp", "sleep", "subw", "tcall", "tclr", "tset", "xcn", "lea", "move", "moves", "moveb", "movew"];
 
-var asar_keywords = ["lorom", "hirom", "exlorom", "exhirom", "sa1rom", "fullsa1rom", "sfxrom", "norom", "macro", "endmacro", "struct", "endstruct", "extends", "incbin", "incsrc", "fillbyte", "fillword", "filllong", "filldword", "fill", "padbyte", "pad", "padword", "padlong", "paddword", "table", "cleartable", "ltr", "rtl", "skip", "namespace", "import", "print", "org", "warnpc", "base", "on", "off", "reset", "freespaceuse", "pc", "bytes", "hex", "freespace", "freecode", "freedata", "ram", "noram", "align", "cleaned", "static", "autoclean", "autoclear", "prot", "pushpc", "pullpc", "pushbase", "pullbase", "function", "if", "else", "elseif", "endif", "while", "assert", "arch", "65816", "spc700", "spc700", "inline", "superfx", "math", "pri", "round", "xkas", "bankcross", "bank", "noassume", "auto", "asar", "includefrom", "includeonce", "include", "error", "skip", "double", "round", "pushtable", "pulltable", "undef", "check", "title", "nested", "warnings", "push", "pull", "disable", "enable", "warn" ];
+var asar_keywords = ["lorom", "hirom", "exlorom", "exhirom", "sa1rom", "fullsa1rom", "sfxrom", "norom", "macro", "endmacro", "struct", "endstruct", "extends", "incbin", "incsrc", "fillbyte", "fillword", "filllong", "filldword", "fill", "padbyte", "pad", "padword", "padlong", "paddword", "table", "cleartable", "ltr", ",rtl", "skip", "namespace", "import", "print", "org", "warnpc", "base", "on", "off", "reset", "freespaceuse", "pc", "bytes", "hex", "freespace", "freecode", "freedata", "ram", "noram", "align", "cleaned", "static", "autoclean", "autoclear", "prot", "pushpc", "pullpc", "pushbase", "pullbase", "function", "if", "else", "elseif", "endif", "while", "assert", "arch", "65816", "spc700", "inline", "superfx", "math", "pri", "round", "xkas", "bankcross", "bank", "noassume", "auto", "asar", "includefrom", "includeonce", "include", "error", "skip", "double", "round", "pushtable", "pulltable", "undef", "check", "title", "nested", "warnings", "push", "pull", "disable", "enable", "warn", "address", "dpbase", "optimize", "dp", "none", "always", "default", "mirrors"];
 
 var asar_intrinsic_functions = ["read1", "read2", "read3", "read4", "canread1", "canread2", "canread4", "sqrt", "sin", "cos", "tan", "asin", "acos", "atan", "arcsin", "arccos", "arctan", "log", "log10", "log2", "_read1", "_read2", "_read3", "_read4", "_canread1", "_canread2", "_canread4", "_sqrt", "_sin", "_cos", "_tan", "_asin", "_acos", "_atan", "_arcsin", "_arccos", "_arctan", "_log", "_log10", "_log2", "readfile1", "_readfile1", "readfile2", "_readfile2", "readfile3", "_readfile3", "readfile4", "_readfile4", "canreadfile1", "_canreadfile1", "canreadfile2", "_canreadfile2", "canreadfile3", "_canreadfile3", "canreadfile4", "_canreadfile4", "canreadfile", "_canreadfile", "filesize", "_filesize", "getfilestatus", "_getfilestatus", "snestopc", "_snestopc", "pctosnes", "_pctosnes", "max", "_max", "min", "_min", "clamp", "_clamp", "safediv", "_safediv", "select", "_select", "not", "_not", "equal", "_equal", "notequal", "_notequal", "less", "_less", "lessequal", "_lessequal", "greater", "_greater", "greaterequal", "_greaterequal", "and", "_and", "or", "_or", "nand", "_nand", "nor", "_nor", "xor", "_xor", "defined", "_defined", "sizeof", "_sizeof", "objectsize", "_objectsize", "stringsequal", "_stringsequal", "stringsequalnocase", "_stringsequalnocase"];
 
@@ -64,20 +64,24 @@ hljs.registerLanguage("65c816_asar",
 					r: 0
 				},
 				{
+					cN: "keywords",
+					b: asar_keywords.join('\\b|').concat('\\b')
+				},
+				{
 					cN: "number",
 					v:
 					[
 						{
-							b: "#?[+-~]?0x[0-9a-fA-F]+"
+							b: "#?[+\\-~]?0x[0-9a-fA-F]+"
 						},
 						{
-							b: "#?[+-~]?[0-9]+(\\.[0-9]+)?"
+							b: "#?[+\\-~]?[0-9]+(\\.[0-9]+)?"
 						},
 						{
-							b: "#?[+-~]?%[0-1]+"
+							b: "#?[+\\-~]?%[0-1]+"
 						},
 						{
-							b: "#?[+-~]?\\$[0-9a-fA-F]+"
+							b: "#?[+\\-~]?\\$[0-9a-fA-F]+"
 						}/*,
 						{
 							b: "#?(\\(|\\)|\\+|\\-|\\*|\\/|\\%|\\<\\<|\\>\\>|\\&|\\||\\^|\\~|\\*\\*)+"
@@ -110,26 +114,8 @@ hljs.registerLanguage("65c816_asar",
 					r: 0
 				},
 				{
-					cN: "keywords",
-					b: asar_keywords.join('|')
-				},
-				{
 					cN: "opcodes",
-					v:
-					[
-						{
-							b: asar_opcodes.join('|')
-						}
-					]
-				},
-				{
-					cN: "opcodes",
-					v:
-					[
-						{
-							b: "[^!%a-zA-Z][a-zA-Z][^a-zA-Z]"
-						}
-					]
+					b: asar_opcodes.join('(\\.[bwl]|\\b)|').concat('(\\.[bwl]|\\b)')
 				},
 				{
 					cN: "label",


### PR DESCRIPTION
- Fixed confusion between keywords/opcodes
- Fixed structs indexing identifying [ as a number
- Added missing keywords, removed a duplicate
- Changed a `Table` to `DataTable` label to prevent conflicts with the `table` keyword
- Swapped order of ltr/rtl in table command to prevent conflicts.