### PR TITLE
Improvement: Add support for 16bit constant from two ascii chars

### DIFF
--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -1529,6 +1529,9 @@ lda #~$80	; Equal to lda #$FFFFFF7F</code></pre>
 		<pre><code class="65c816_asar">lda #'a'
 sta $00
 
+lda.w #'bc'
+sta $01
+
 db 'x','x'+1,'x'+2</code></pre>
 		<h4 id="opcode-length">Opcode Length Specification</h4>
 		By appending <code>.b</code>, <code>.w</code> or <code>.l</code> to an opcode, you can specify that opcode's length. This is recommended in cases where the length could be ambiguous.

--- a/src/asar/asar_math.cpp
+++ b/src/asar/asar_math.cpp
@@ -734,8 +734,12 @@ static double getnumcore()
 	}
 	if (*str=='\'')
 	{
-		if (!str[1] || str[2] != '\'') asar_throw_error(1, error_type_block, error_id_invalid_character);
+		if (!str[1] || (str[2] != '\'' && str[3] != '\'')) asar_throw_error(1, error_type_block, error_id_invalid_character);
 		unsigned int rval=table.table[(unsigned char)str[1]];
+		if(str[3] == '\''){
+			rval = rval ^ (table.table[(unsigned char)str[2]] << 8);
+			str+=1;
+		}
 		str+=3;
 		return rval;
 	}

--- a/src/asar/main.cpp
+++ b/src/asar/main.cpp
@@ -253,6 +253,11 @@ notposneglabel:
 			thislen=1;
 			str+=3;
 		}
+		else if (str[0]=='\'' && str[3]=='\'')
+		{
+			thislen=2;
+			str+=4;
+		}
 		else if (is_digit(*str))
 		{
 			int val=strtol(str, const_cast<char**>(&str), 10);


### PR DESCRIPTION
Minor changes to add support for 16bit values made of two chars, eg.: `lda.w #'AS' : sta $00 : lda.w #'AR' : sta $02`