### PR TITLE
Implemented function to convert RGB colors to RGB555 value

### DIFF
--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -2627,6 +2627,12 @@ max(a, b)</code></td>
 				<td><pre><code class="65c816_asar">lda #bank(some_label)</code></pre></td>
 			</tr>
 			<tr>
+				<td><code class="65c816_asar">rgb555(value[, value, value])</code></td>
+				<td>Converts any RGB color to a valid RGB555 <code>(?bbbbbgg gggrrrrr)</code></td>
+				<td><pre><code class="65c816_asar">lda.w #rgb555($0000FF) : sta $2122 ; blue
+lda.w #rgb555(255,0,0) : sta $2122 ; red</code></pre></td>
+			</tr>
+			<tr>
 				<td><code class="65c816_asar">equal(value, comparand)
 notequal(value, comparand)
 less(value, comparand)

--- a/src/asar/asar_math.cpp
+++ b/src/asar/asar_math.cpp
@@ -513,6 +513,20 @@ static double asar_stringsequalnocase()
 	return (stricmp(string1, get_string_argument()) == 0 ? 1.0 : 0.0);
 }
 
+static double asar_rgb555()
+{
+	int value = get_double_argument();
+	if(has_next_parameter()){
+		value = value << 10;
+		value |= (int) get_double_argument() << 5;
+		require_next_parameter();
+		value |= (int) get_double_argument();
+	} else {
+		value = ((value >> 16) << 10) | (((value >> 8) & 0xFF) << 5) | (value & 0xFF);
+	}
+	return value & 0x7FFF;
+}
+
 string copy_arg()
 {
 	if(*str == '"')
@@ -611,7 +625,9 @@ assocarr<double (*)()> builtin_functions =
 	{"datasize", asar_datasize_wrapper},
 	
 	{"stringsequal", asar_stringsequal},
-	{"stringsequalnocase", asar_stringsequalnocase}
+	{"stringsequalnocase", asar_stringsequalnocase},
+
+	{"rgb555", asar_rgb555}
 };
 
 assocarr<double (*)()> functions;


### PR DESCRIPTION
I've been doing it with custom functions but wanted to make another contribution to Asar.

This PR adds a new builtin function called "rgb555" (sugestion), that you can easily convert colors from hexadecimal `rgb555($FF00FF)` or like this `rgb555(255, 0, 255)`

That's it... =)