### PR TITLE
Restore --version handling to the common behavior

### DIFF
--- a/src/asar/interface-cli.cpp
+++ b/src/asar/interface-cli.cpp
@@ -317,10 +317,9 @@ int main(int argc, char * argv[])
 				}
 			}
 		}
-		if (verbose && !printed_version)
+		if (verbose)
 		{
 			puts(version);
-			printed_version = true;
 		}
 		string asmname=libcon_require_filename("Enter patch name:");
 		string romname=libcon_optional_filename("Enter ROM name:", nullptr);

--- a/src/asar/interface-cli.cpp
+++ b/src/asar/interface-cli.cpp
@@ -167,7 +167,6 @@ int main(int argc, char * argv[])
 		bool verbose=libcon_interactive;
 		string symbols="";
 		string symfilename="";
-		bool printed_version=false;
 
 		autoarray<string> includepaths;
 		autoarray<const char*> includepath_cstrs;
@@ -193,14 +192,8 @@ int main(int argc, char * argv[])
 			}
 			else if (par=="--version")
 			{
-				if (!printed_version)
-				{
-					puts(version);
-					printed_version = true;
-					// RPG Hacker: ...why?!?
-					// Keep finding these useless exit cases in all kinds of applications.
-					//return 0;
-				}
+				puts(version);
+				return 0;
 			}
 			else if (checkstartmatch(par, "--pause-mode="))
 			{


### PR DESCRIPTION
I agree it's weird that this specific option discards all other arguments, but all other tools special case --help and --version, better follow suit.

No change needed for --help; it already terminates the process, via the unknown option handler.