### PR TITLE
fix missing space in @includefrom error

### DIFF
--- a/src/asar/assembleblock.cpp
+++ b/src/asar/assembleblock.cpp
@@ -1283,7 +1283,7 @@ void assembleblock(const char * block, bool isspecialline)
 		if (!asarverallowed) asar_throw_error(0, error_type_block, error_id_start_of_file);
 		if (istoplevel)
 		{
-			if (par) asar_throw_error(pass, error_type_fatal, error_id_cant_be_main_file, (string("The main file is '") + STR par + STR "'.").data());
+			if (par) asar_throw_error(pass, error_type_fatal, error_id_cant_be_main_file, (string(" The main file is '") + STR par + STR "'.").data());
 			else asar_throw_error(pass, error_type_fatal, error_id_cant_be_main_file, "");
 		}
 	}


### PR DESCRIPTION
[15:41:30]  \<Alcaro> !rb as -n 
@includefrom asm.asm
[15:41:32]  \<randombot999> Errors occurred while assembling.
\<input>:1: error: (E5123): This file may not be used as the main file.The main file is 'asm.asm'. [includefrom asm.asm]