### PR TITLE
Include 'autoclean ...' lines in AddrToLineInfo

### DIFF
--- a/src/asar/assembleblock.cpp
+++ b/src/asar/assembleblock.cpp
@@ -1961,6 +1961,9 @@ void assembleblock(const char * block, bool isspecialline)
 					{
 						asar_throw_error(2, error_type_block, error_id_autoclean_label_at_freespace_end);
 					}
+
+					extern AddressToLineMapping addressToLineMapping;
+					addressToLineMapping.includeMapping(thisfilename.data(), thisline + 1, addrToLinePos);
 				}
 				//freespaceorglen[targetid]=read2(ratsloc-4)+1;
 				freespaceorgpos[targetid]=ratsloc;


### PR DESCRIPTION
Previously, lines that start with "autoclean" do not an entry in e.g. the `.wla` file's `[addr-to-line mapping]` section. This fixes that issue.