### PR TITLE
add proper errors for phantom errors

### DIFF
--- a/src/asar/errors.cpp
+++ b/src/asar/errors.cpp
@@ -286,6 +286,7 @@ static asar_error_mapping asar_errors[] =
 	{ error_id_cmdl_utf16_to_utf8_failed, "UTF-16 to UTF-8 string conversion failed: %s." },
 
 	{ error_id_broken_command, "Broken %s command. %s" },
+	{ error_id_phantom_error, "A phantom error occurred. This is an Asar bug, please report it: https://github.com/RPGHacker/asar/issues" },
 };
 // RPG Hacker: Sanity check. This makes sure that the element count of asar_errors
 // matches with the number of constants in asar_error_id. This is important, because

--- a/src/asar/errors.h
+++ b/src/asar/errors.h
@@ -264,6 +264,7 @@ enum asar_error_id : int
 	error_id_cmdl_utf16_to_utf8_failed,
 
 	error_id_broken_command,
+	error_id_phantom_error,
 
 	error_id_end,
 	error_id_count = error_id_end - error_id_start - 1,

--- a/src/asar/interface-cli.cpp
+++ b/src/asar/interface-cli.cpp
@@ -463,6 +463,8 @@ int main(int argc, const char * argv[])
 		//if (pcpos>romlen) romlen=pcpos;
 		if (errored)
 		{
+			if (errnum==0)
+				asar_throw_error(pass, error_type_null, error_id_phantom_error);
 			puts("Errors were detected while assembling the patch. Assembling aborted. Your ROM has not been modified.");
 			closerom(false);
 			reseteverything();

--- a/src/asar/interface-lib.cpp
+++ b/src/asar/interface-lib.cpp
@@ -228,6 +228,8 @@ static bool asar_patch_end(char * romdata_, int buflen, int * romlen_)
 	if (buflen < romlen) asar_throw_error(pass, error_type_null, error_id_buffer_too_small);
 	if (errored)
 	{
+		if (numerror==0)
+			asar_throw_error(pass, error_type_null, error_id_phantom_error);
 		free(const_cast<unsigned char*>(romdata));
 		return false;
 	}


### PR DESCRIPTION
should deconfuse a handful of users

may also fix dll callers that check if number of errors is zero

but most importantly, it looks stupid in !rb as

guaranteed untested™, i probably missed a semicolon or something