### PR TITLE
Fix asar-exe-test deadlock because write pipe is full

### DIFF
--- a/src/asar-tests/test.cpp
+++ b/src/asar-tests/test.cpp
@@ -261,7 +261,10 @@ static bool execute_command_line(char * commandline, const char * stdout_log_fil
 	sa.bInheritHandle = TRUE;
 	sa.lpSecurityDescriptor = nullptr;
 
-	if (!CreatePipe(&stdout_read_handle, &stdout_write_handle, &sa, 0))
+	SYSTEM_INFO sInfo{};
+	GetSystemInfo(&sInfo);
+
+	if (!CreatePipe(&stdout_read_handle, &stdout_write_handle, &sa, sInfo.dwPageSize * 4))
 	{
 		return false;
 	}
@@ -273,7 +276,7 @@ static bool execute_command_line(char * commandline, const char * stdout_log_fil
 		return false;
 	}
 
-	if (!CreatePipe(&stderr_read_handle, &stderr_write_handle, &sa, 0))
+	if (!CreatePipe(&stderr_read_handle, &stderr_write_handle, &sa, sInfo.dwPageSize * 4))
 	{
 		CloseHandle(stdout_read_handle);
 		CloseHandle(stdout_write_handle);


### PR DESCRIPTION
Previously the created pipe had a size of 4096, this lead to a deadlock on the xkasemu.asm test because it output 4400~ bytes of output, which, since not read from the other side, caused the pipe to become full and stop accepting input, blocking everything. 

This patch fixes it by simply using pageSize * 4 as a size, which is 4096 * 4 bytes. If a test surpasses 4096 * 4 bytes of output, it'll lock up again, for now this is not the case, however in the future a "better" fix would be to read from the pipe continously instead of at the end, as to not let it get full.