### PR TITLE
Don't removerats twice when two autocleans point to the same freespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ These two characters should precede each test line, so that Asar sees them as co
 * 2 hex digits - a byte for it to check for 
   * You can specify more than one, like in the examples below, and it will automatically increment the offset.
 * A line starting with `+` tells the testing app to patch the SMW ROM instead of creating a new ROM
+* `#` followed by a decimal number tells the testing app to apply the patch that number of times repeatedly
 * `errEXXXX` and `warnWXXXX` (where `XXXX` is an ID number) means that the test is expected to throw that specific error or warning while patching. The test will succeed only if the number and order of errors and warnings thrown exactly matches what's specified here. Be wary that Asar uses multiple passes and throws errors and warnings across multiple of them. This can make the actual order in which errors and warnings are thrown a bit unintuitive.
 
 In addition to the format mentioned above, it's also possible to check for user prints a patch is expected to output (by `print`, `error`, `warn` or `assert` commands). This is done by starting the line with one of the following sequences:

--- a/src/asar-tests/test.cpp
+++ b/src/asar-tests/test.cpp
@@ -245,7 +245,7 @@ static void delete_file(const char * filename)
 // RPG Hacker: Original test application used system(), but
 // that really made my anti-virus sad, so here is a new,
 // complicated platform-specific solution.
-// NOTE: No cont char*, for commandline, because CreateProcess()
+// NOTE: No const char*, for commandline, because CreateProcess()
 // actually can mess with this string for some reason...
 static bool execute_command_line(char * commandline, const char * stdout_log_file, const char * stderr_log_file)
 {

--- a/src/asar/assembleblock.cpp
+++ b/src/asar/assembleblock.cpp
@@ -1953,16 +1953,13 @@ void assembleblock(const char * block, bool isspecialline)
 			if (pass==1) freespaceleak[targetid]=false;
 			auto is_freespace_reused = [](int ratsloc) -> bool
 			{
-				bool freespace_reused = false;
 				for (int i = 0; i < freespaceidnext; i++)
 				{
 					if (freespacepos[i] != -1 && (freespacepos[i] & 0xFFFFFF) == ratsloc) {
-						freespace_reused = true;
-						break;
+						return true;
 					}
 				}
-
-				return freespace_reused;
+				return false;
 			};
 			num&=0xFFFFFF;
 			if (strlen(par)>3 && !stricmp(par+3, ".l")) par[3]=0;

--- a/tests/autoclean_2freecode_to_1freecode.asm
+++ b/tests/autoclean_2freecode_to_1freecode.asm
@@ -1,0 +1,41 @@
+;`+ #2
+;`000000
+;`22 08 80 90
+;`22 09 80 90
+;`07FD7 0A
+;`80000
+;`53 54 41 52 01 00 FE FF 6B 6B
+;`FFFFF 00
+
+
+org $008000
+
+if read1($008000) != $22
+
+; print "first run"
+
+autoclean jsl hijack1
+autoclean jsl hijack2
+
+freecode
+hijack1:
+rtl
+
+freecode
+hijack2:
+rtl
+
+else
+
+; print "second run"
+
+autoclean jsl hijack1
+autoclean jsl hijack2
+
+freecode
+hijack1:
+rtl
+hijack2:
+rtl
+
+endif

--- a/tests/autoclean_twice.asm
+++ b/tests/autoclean_twice.asm
@@ -1,0 +1,30 @@
+;`+ #2
+;`000000
+;`22 09 80 90
+;`22 13 80 90
+;`000020
+;`22 09 80 90
+;`07FD7 0A
+;`080000 53 54 41 52 01 00 FE FF 01 01 53 54 41 52 01 00
+;`080010 FE FF 02 02
+;`FFFFF 00
+
+;print "previous test1: $",hex(read3($008000+1))
+;print "previous test2: $",hex(read3($008004+1))
+;print "new test1: $",hex(test1)
+;print "new test2: $",hex(test2)
+
+org $008000
+autoclean JSL test1
+autoclean JSL test2
+
+freecode
+db 1
+test1: db 1
+
+org $008020
+autoclean JSL test1
+
+freecode
+db 2
+test2: db 2


### PR DESCRIPTION
Fixes #216

No test added. Since this bug requires existing RATS tags to repro, I don't think the current testing framework would support a test for this.
