### PR TITLE
Set PDB_NAME to something other than asar

### DIFF
--- a/src/asar/CMakeLists.txt
+++ b/src/asar/CMakeLists.txt
@@ -209,7 +209,7 @@ if(ASAR_GEN_EXE)
 	endif()
 	
 	set_target_properties(asar-standalone PROPERTIES OUTPUT_NAME "asar")
-	set_target_properties(asar-standalone PROPERTIES PDB_NAME "asar-standalone")
+	set_target_properties(asar-standalone PROPERTIES PDB_NAME "asar.exe")
 endif(ASAR_GEN_EXE)
 
 
@@ -229,4 +229,6 @@ if(ASAR_GEN_DLL)
 	)
 	target_compile_definitions(asar PRIVATE "ASAR_SHARED")
 	set_asar_shared_properties(asar)
+
+	set_target_properties(asar PROPERTIES PDB_NAME "asar.dll")
 endif(ASAR_GEN_DLL)

--- a/src/asar/CMakeLists.txt
+++ b/src/asar/CMakeLists.txt
@@ -209,6 +209,7 @@ if(ASAR_GEN_EXE)
 	endif()
 	
 	set_target_properties(asar-standalone PROPERTIES OUTPUT_NAME "asar")
+	set_target_properties(asar-standalone PROPERTIES PDB_NAME "asar-standalone")
 endif(ASAR_GEN_EXE)
 
 


### PR DESCRIPTION
CMake was automatically setting the PDB_NAME to be asar.pdb, which on Windows conflicts with the dlls pdb name, since it's the same (asar.dll -> asar.pdb). This was giving arcane linker errors since it was trying to write the same file at the same time from 2 places and it completely broke debugging on Visual Studio, since it wasn't loading the debug symbols. Setting the PDB_NAME alone works fine, symbols load correctly and there are no linker errors. 
This was also tested on Linux to confirm that it works just fine, cmake just ignores the property but doesn't complain.