### PR TITLE
Reduce warnings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_policy(SET CMP0091 NEW)
 project(Asar)
 
 cmake_minimum_required(VERSION 3.9.0)

--- a/src/asar/CMakeLists.txt
+++ b/src/asar/CMakeLists.txt
@@ -19,12 +19,19 @@ set (CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG} -fsanitize=address")
 # stand-alone application and library interface
 
 macro(set_asar_shared_properties target msvc_lib_type_param enable_sanitizer)
+	# this is here because in CMake you can't modify macro parameters
+	# so we create a new variable
+	set(msvc_lib_type_var ${msvc_lib_type_param})
 	if (MSVC)
 		if (MSVC_LIB_TYPE)
-			set(msvc_lib_type_param ${MSVC_LIB_TYPE})
+			set(msvc_lib_type_var ${MSVC_LIB_TYPE})
 		endif()
-		if (NOT (${msvc_lib_type_param} STREQUAL "D" OR ${msvc_lib_type_param} STREQUAL "T"))
-			message(FATAL_ERROR "Invalid MSVC_LIB_TYPE, valid types are T and D")
+		if ("${msvc_lib_type_var}" STREQUAL "D")
+			set_property(TARGET ${target} PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+		elseif ("${msvc_lib_type_var}" STREQUAL "T")
+			set_property(TARGET ${target} PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+		else()
+			message(FATAL_ERROR "Invalid MSVC_LIB_TYPE, valid types are T and D instead of ${msvc_lib_type_param}")
 		endif()
 	endif()
 
@@ -74,7 +81,7 @@ macro(set_asar_shared_properties target msvc_lib_type_param enable_sanitizer)
 	# Enable maximum warning level
 	
 	if(MSVC)
-		target_compile_options(${target} PRIVATE /Wall "/M${msvc_lib_type_param}$<$<CONFIG:Debug>:d>" /EHa)
+		target_compile_options(${target} PRIVATE /W3 /EHa)
 		
 		# These certainly aren't worth a warning, though
 		target_compile_options(${target} PRIVATE
@@ -83,6 +90,8 @@ macro(set_asar_shared_properties target msvc_lib_type_param enable_sanitizer)
 			/wd4711 # function selected for automatic inline expansion
 			/wd4820 # 'bytes' bytes padding added after construct 'member_name'
 			/wd4464 # relativ include path contains '..'
+			/wd4244 # 'conversion' conversion from 'type1' to 'type2', possible loss of data
+			/wd5045 # compiler will insert Spectre mitigation for memory load if /Qspectre switch specified
 		)
 		target_link_options(${target} PRIVATE /STACK:4194304)
 		if(MSVC_VERSION VERSION_LESS "1900")

--- a/src/asar/CMakeLists.txt
+++ b/src/asar/CMakeLists.txt
@@ -31,7 +31,7 @@ macro(set_asar_shared_properties target msvc_lib_type_param enable_sanitizer)
 		elseif ("${msvc_lib_type_var}" STREQUAL "T")
 			set_property(TARGET ${target} PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 		else()
-			message(FATAL_ERROR "Invalid MSVC_LIB_TYPE, valid types are T and D instead of ${msvc_lib_type_param}")
+			message(FATAL_ERROR "Invalid MSVC_LIB_TYPE, valid types are T and D instead of ${msvc_lib_type_var}")
 		endif()
 	endif()
 


### PR DESCRIPTION
This patch makes the number of warnings on the MSVC build of asar go from 2.8k to ~160. 

The main reducer is going from /Wall to /W3. Since /Wall is like clang's [-Weverything](https://clang.llvm.org/docs/UsersManual.html#diagnostics-enable-everything), it tends to be overly noisy and warn about unimportant things, /W3 is much less noisy while still warning about the more important stuff.

Additionally I turned off warnings [4244 ](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-levels-3-and-4-c4244?view=msvc-170) and [5045](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5045?view=msvc-170), 4244 because it was causing ~350 warnings alone and as such I doubt they'd all get fixed manually one by one and 5045 because it's a pretty useless warning in asar's case. 

To remove another ~90 warnings given by [9025 ](https://docs.microsoft.com/en-us/cpp/error-messages/tool-errors/command-line-warning-d9025?view=msvc-170) I made use of CMake's [MSVC_RUNTIME_LIBRARY](https://cmake.org/cmake/help/v3.24/prop_tgt/MSVC_RUNTIME_LIBRARY.html) target property. This is because if you manually specify /MT or /MD on the target_compile_options() CMake will just append them resulting in both /MT and /MD in the command line, because [from CMake's docs]

> If this property is not set then CMake uses the default value MultiThreaded$<$<CONFIG:Debug>:Debug>DLL to select a MSVC runtime library.

obviously the compiler will ignore the first and only use the second one but it will still print a warning about it. Using that specific target property avoids the duplicate command line flag and thus the warning. Note that this is why I had to add 

`cmake_policy(SET CMP0091 NEW)`.