### PR TITLE
Fix a vfs bug and enable compilation when using C++17 or later on Windows.

### DIFF
--- a/src/asar/interface-cli.cpp
+++ b/src/asar/interface-cli.cpp
@@ -44,7 +44,7 @@ void error_interface(int errid, int whichpass, const char * e_)
 		errnum++;
 		// don't show current block if the error came from an error command
 		bool show_block = (thisblock && (errid != error_id_error_command));
-		fputs(STR getdecor() + "error: (E" + dec(errid) + "): " + e_ + (show_block ? (STR" [" + thisblock + "]") : "") + "\n", errloc);
+		fputs(STR getdecor() + "error: (E" + dec(errid) + "): " + e_ + (show_block ? (STR" [" + thisblock + "]") : STR "") + "\n", errloc);
 		static const int max_num_errors = 20;
 		if (errnum == max_num_errors + 1) asar_throw_error(pass, error_type_fatal, error_id_limit_reached, max_num_errors);
 	}
@@ -57,7 +57,7 @@ void warn(int errid, const char * e_)
 {
 	// don't show current block if the warning came from a warn command
 	bool show_block = (thisblock && (errid != warning_id_warn_command));
-	fputs(STR getdecor()+"warning: (W" + dec(errid) + "): " + e_ + (show_block ? (STR" [" + thisblock + "]") : "") + "\n", errloc);
+	fputs(STR getdecor()+"warning: (W" + dec(errid) + "): " + e_ + (show_block ? (STR" [" + thisblock + "]") : STR "") + "\n", errloc);
 	warned=true;
 }
 

--- a/src/asar/interface-lib.cpp
+++ b/src/asar/interface-lib.cpp
@@ -90,7 +90,7 @@ static void fillerror(errordata& myerr, int errid, const char * type, const char
 	if (thisblock) myerr.block= duplicate_string(thisblock);
 	else myerr.block= duplicate_string("");
 	myerr.rawerrdata= duplicate_string(str);
-	myerr.fullerrdata= duplicate_string(STR getdecor()+type+str+((thisblock&&show_block)?(STR" ["+thisblock+"]"):""));
+	myerr.fullerrdata= duplicate_string(STR getdecor()+type+str+((thisblock&&show_block)?(STR" ["+thisblock+"]"):STR ""));
 	myerr.callerline=callerline;
 	myerr.callerfilename=callerfilename ? duplicate_string(callerfilename) : nullptr;
 	myerr.errid = errid;

--- a/src/asar/virtualfile.cpp
+++ b/src/asar/virtualfile.cpp
@@ -259,8 +259,9 @@ virtual_filesystem::virtual_file_type virtual_filesystem::get_file_type_from_pat
 
 void virtual_filesystem::add_memory_file(const char* name, const void* buffer, size_t length) {
 	memory_buffer mem_buf = { buffer, length };
-	m_memory_files.remove(name);
-	m_memory_files.create(name) = mem_buf;
+	string normalized_path = normalize_path(name);
+	m_memory_files.remove(normalized_path);
+	m_memory_files.create(normalized_path) = mem_buf;
 	
 }
 


### PR DESCRIPTION
- Fix a vfs bug where mixed-case filenames weren't being found by memory_files.exists().
- Make compilation possible on Windows when using C++17 or later (prevent C2445)