### PR TITLE
src/asar: fix -Wmisleading-indentation warnings

### DIFF
--- a/src/asar/arch-spc700.cpp
+++ b/src/asar/arch-spc700.cpp
@@ -329,8 +329,15 @@ bool asblock_spc700(char** word, int numwords)
 #define vc(left1, right1, str2) if (isvc(left1, right1, str2))
 #define vv(left1, right1, left2, right2) if (isvv(left1, right1, left2, right2))
 #define w0(opcode) do { write1((unsigned int)opcode); return true; } while(0)
-#define w1(opcode, math) do { write1((unsigned int)opcode); unsigned int val=getnum_ck(math); \
-		if ((((val&0xFF00)&&(val&0x80000000)==0)||(((val&0xFF00)!=0xFF00)&&(val&0x80000000)))&&opLen!=1) asar_throw_warning(2, warning_id_spc700_assuming_8_bit); write1(val);return true; } while(0)
+#define w1(opcode, math) \
+	do { \
+		write1((unsigned int)opcode); \
+		unsigned int val=getnum_ck(math); \
+		if ((((val&0xFF00) && (val&0x80000000) == 0) || (((val&0xFF00) != 0xFF00) && (val&0x80000000))) && opLen != 1) \
+			asar_throw_warning(2, warning_id_spc700_assuming_8_bit); \
+		write1(val);\
+		return true; \
+	} while(0)
 #define w2(opcode, math) do { write1((unsigned int)opcode); write2(getnum_ck(math)); return true; } while(0)
 #define wv(opcode1, opcode2, math) do { if ((opLen == 1) || (opLen == 0 && getlen(math)==1)) { write1((unsigned int)opcode1); write1(getnum_ck(math)); } \
 																	 else { write1((unsigned int)opcode2); write2(getnum_ck(math)); } return true; } while(0)

--- a/src/asar/libstr.cpp
+++ b/src/asar/libstr.cpp
@@ -156,9 +156,50 @@ bool readfile(const char * fname, const char * basepath, char ** data, int * len
 	return true;
 }
 
-#define dequote(var, next, error) if (var=='"') do { next; while (var!='"' && var != '\0') { if (!var) error; next; }	if (var == '\0') error;	next; } while(0); else if (var=='\'') do { next; if (!var) error; /* ''' special case hack */ if (var=='\'') { next; if (var!='\'') error; next; } else { next; while (var!='\'' && var != '\0') { if (!var) error; next; } if (var == '\0') error; next; } } while(0)
-#define skippar(var, next, error) dequote(var, next, error); else if (var=='(') { int par=1; next; while (par) { dequote(var, next, error); else { \
-				if (var=='(') par++; if (var==')') par--; if (!var) error; next; } } } else if (var==')') error
+#define dequote(var, next, error) \
+	if (var=='"') \
+		do { \
+			next; \
+			while (var!='"' && var != '\0') { \
+				if (!var) error; \
+				next; \
+			} \
+			if (var == '\0') error; \
+			next; \
+		} while(0); \
+	else if (var=='\'') \
+		do { \
+			next; \
+			if (!var) error; /* ''' special case hack */ \
+			if (var=='\'') { \
+				next; \
+				if (var!='\'') error; \
+				next; \
+			} else { \
+				next; \
+				while (var!='\'' && var != '\0') { \
+					if (!var) error; \
+					next; \
+				} \
+				if (var == '\0') error; \
+				next; \
+			} \
+		} while(0)
+
+#define skippar(var, next, error) \
+	dequote(var, next, error); \
+	else if (var=='(') { \
+		int par=1; next; \
+		while (par) { \
+			dequote(var, next, error); \
+			else { \
+				if (var=='(') par++; \
+				if (var==')') par--; \
+				if (!var) error; \
+				next; \
+			} \
+		} \
+	} else if (var==')') error
 
 string& string::replace(const char * instr, const char * outstr, bool all)
 {


### PR DESCRIPTION
These macros are impossible to read and cause extremely verbose `-Wmisleading-indentation` warnings.