### PR TITLE
cmake: fix warning

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_policy(SET CMP0091 NEW)
-project(Asar)
-
 cmake_minimum_required(VERSION 3.9.0)
+cmake_policy(SET CMP0091 NEW)
+
+project(Asar)
 
 add_subdirectory(asar)
 


### PR DESCRIPTION
Trivial warning:
```
CMake Warning (dev) at CMakeLists.txt:2 (project):
  cmake_minimum_required() should be called prior to this top-level project()
  call.  Please see the cmake-commands(7) manual for usage documentation of
  both commands.
This warning is for project developers.  Use -Wno-dev to suppress it.
```