### PR TITLE
asar-tests: fix build with musl

### DIFF
--- a/src/asar-tests/test.cpp
+++ b/src/asar-tests/test.cpp
@@ -28,7 +28,6 @@
 #	include <algorithm>
 #	include <set>
 #	include <list>
-#	include <cstdint>
 #	include <errno.h>
 
 #	if defined(_MSC_VER)
@@ -47,6 +46,8 @@
 #	include <list>
 #	include <errno.h>
 #endif
+
+#include <cstdint>
 
 #if defined(ASAR_TEST_DLL)
 #	include "asardll.h"


### PR DESCRIPTION
Trivial build fix for musl systems, this is a standard header and it should be safe to include everywhere even if the libc implicitly includes it already.
```
src/asar-tests/test.cpp: In function 'int main(int, char**)':
src/asar-tests/test.cpp:958:57: error: 'int64_t' was not declared in this scope
  958 |          test_status &= (int64_t)asar_math("1+0", &error_buffer) == 1;
      |                          ^~~~~~~
```