### PR TITLE
asar-tests: fix -Wformat-truncation warning

### DIFF
--- a/src/asar-tests/test.cpp
+++ b/src/asar-tests/test.cpp
@@ -698,11 +698,11 @@ int main(int argc, char * argv[])
 	{
 		char * fname = input_files[testno].file_path;
 
-		char out_rom_name[512];
+		char out_rom_name[256];
 		snprintf(out_rom_name, sizeof(out_rom_name), "%s%s%s%s", output_directory, (has_path_seperator ? "" : "/"), input_files[testno].file_name, ".sfc");
-		char stdout_log_name[512];
+		char stdout_log_name[256];
 		snprintf(stdout_log_name, sizeof(stdout_log_name), "%s%s%s%s", output_directory, (has_path_seperator ? "" : "/"), input_files[testno].file_name, ".stdout.log");
-		char stderr_log_name[512];
+		char stderr_log_name[256];
 		snprintf(stderr_log_name, sizeof(stderr_log_name), "%s%s%s%s", output_directory, (has_path_seperator ? "" : "/"), input_files[testno].file_name, ".stderr.log");
 
 		// Delete files if they already exist, so we don't get leftovers from a previous testrun


### PR DESCRIPTION
Gentoo considers this warning to be a QA issue for the ebuild and prints an additional warning.

Please review for correctness, I don't think these need to be `512` and the tests work fine on my end.
```
/tmp/asar/src/asar-tests/test.cpp: In function 'int main(int, char**)':
/tmp/asar/src/asar-tests/test.cpp:1019:44: warning: '%s' directive output may be truncated writing up to 511 bytes into a region of size between 381 and 892 [-Wformat-truncation=]
 1019 |                                 " \"%s\" \"%s\"",
      |                                            ^~
 1020 |                                 asar_exe_path, base_path, fname, out_rom_name);
      |                                                                  ~~~~~~~~~~~~
/tmp/asar/src/asar-tests/test.cpp:1015:33: note: 'snprintf' output 134 or more bytes (assuming 1156) into a destination of size 1024
 1015 |                         snprintf(cmd, sizeof(cmd),
      |                         ~~~~~~~~^~~~~~~~~~~~~~~~~~
 1016 |                                 "\"%s\" -I\"%s\" -Dcli_only=\\$1 -Dcmddefined -D!cmddefined2= --define \" !cmddefined3 = 16,240,224 \""
      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1017 |                                 // RPG Hacker: 日本語������ǵ in UTF-8
      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1018 |                                 " -Dcmdl_define_utf8=\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e\xf0\x9f\x87\xaf\xf0\x9f\x87\xb5"
      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1019 |                                 " \"%s\" \"%s\"",
      |                                 ~~~~~~~~~~~~~~~~~
 1020 |                                 asar_exe_path, base_path, fname, out_rom_name);
      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```