### PR TITLE
Add missing include in asardll.c

### DIFF
--- a/src/asar-dll-bindings/c/asardll.c
+++ b/src/asar-dll-bindings/c/asardll.c
@@ -1,5 +1,6 @@
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdlib.h>
 
 #if defined(_WIN32)
 #	if defined(_MSC_VER)


### PR DESCRIPTION
This commit adds an `#include <stdlib.h>` in asardll.c This is because otherwise malloc and free functions are not defined anywhere, causing warnings (at least in msvc).

e.g.
warning C4013: 'malloc' undefined; assuming extern returning int 
warning C4013: 'free' undefined; assuming extern returning int