### PR TITLE
Fix resolvedefines not being loaded in the DLL and fix getwrittenblocks not working correctly when building statically

### DIFF
--- a/src/asar-dll-bindings/c/asardll.c
+++ b/src/asar-dll-bindings/c/asardll.c
@@ -141,6 +141,7 @@ static bool asar_init_shared(void)
 	load(getlabelval);
 	load(getdefine);
 	load(getalldefines);
+	load(resolvedefines);
 	load(math);
 	load(getwrittenblocks);
 	load(getmapper);

--- a/src/asar/interface-lib.cpp
+++ b/src/asar/interface-lib.cpp
@@ -493,11 +493,14 @@ EXPORT const char * asar_getdefine(const char * name)
 EXPORT const char * asar_resolvedefines(const char * data)
 {
 	static string out;
+	out = "";
 	try
 	{
 		resolvedefines(out, data);
 	}
-	catch(errfatal&){}
+	catch(errfatal&){
+		out = "";
+	}
 	return out;
 }
 

--- a/src/asar/libsmw.cpp
+++ b/src/asar/libsmw.cpp
@@ -40,6 +40,7 @@ static int findromwritepos(int snesoffset, int searchstartpos, int searchendpos)
 
 static void addromwriteforbank(int snesoffset, int numbytes)
 {
+	if (numbytes == 0) return;
 	int currentbank = (snesoffset & 0xFF0000);
 
 	int insertpos = findromwritepos(snesoffset, 0, writtenblocks.count);

--- a/src/asar/libsmw.cpp
+++ b/src/asar/libsmw.cpp
@@ -19,7 +19,7 @@ asar_error_id openromerror;
 autoarray<writtenblockdata> writtenblocks;
 
 // RPG Hacker: Uses binary search to find the insert position of our ROM write
-#ifdef ASAR_SHARED
+#if defined(ASAR_SHARED) || defined(ASAR_STATIC)
 static int findromwritepos(int snesoffset, int searchstartpos, int searchendpos)
 {
 	if (searchendpos == searchstartpos)
@@ -110,7 +110,7 @@ static void addromwrite(int pcoffset, int numbytes)
 void writeromdata(int pcoffset, const void * indata, int numbytes)
 {
 	memcpy(const_cast<unsigned char*>(romdata) + pcoffset, indata, (size_t)numbytes);
-	#ifdef ASAR_SHARED
+	#if defined(ASAR_SHARED) || defined(ASAR_STATIC)
 		addromwrite(pcoffset, numbytes);
 	#endif
 }
@@ -118,7 +118,7 @@ void writeromdata(int pcoffset, const void * indata, int numbytes)
 void writeromdata_byte(int pcoffset, unsigned char indata)
 {
 	memcpy(const_cast<unsigned char*>(romdata) + pcoffset, &indata, 1);
-	#ifdef ASAR_SHARED
+	#if defined(ASAR_SHARED) || defined(ASAR_STATIC)
 		addromwrite(pcoffset, 1);
 	#endif
 }
@@ -126,7 +126,7 @@ void writeromdata_byte(int pcoffset, unsigned char indata)
 void writeromdata_bytes(int pcoffset, unsigned char indata, int numbytes, bool add_write)
 {
 	memset(const_cast<unsigned char*>(romdata) + pcoffset, indata, (size_t)numbytes);
-	#ifdef ASAR_SHARED
+	#if defined(ASAR_SHARED) || defined(ASAR_STATIC)
 		if(add_write)
 			addromwrite(pcoffset, numbytes);
 	#endif


### PR DESCRIPTION
- Load `asar_resolvedefines` in asardll.c initialization
- Fix `#ifdefs` in conditional compilation that prevented `getwrittenblocks` from reporting correct data when building library statically. 