### PR TITLE
Update math_eval.cpp

### DIFF
--- a/src/asar/math_eval.cpp
+++ b/src/asar/math_eval.cpp
@@ -74,7 +74,7 @@ bool evaluate_binop_compare(const T& lhs, const T& rhs, math_binop_type type) {
 
 static bool evaluate_eq(math_val lhs, math_val rhs) {
 	// if only one is string, they can never be equal
-	if((lhs.m_type == math_val_type::string) ^ (rhs.m_type == math_val_type::string)) {
+	if((lhs.m_type == math_val_type::string) != (rhs.m_type == math_val_type::string)) {
 		return false;
 	}
 	if(lhs.m_type == math_val_type::string) {
@@ -82,12 +82,9 @@ static bool evaluate_eq(math_val lhs, math_val rhs) {
 		return lhs.get_str() == rhs.get_str();
 	} else {
 		// both non strings: compare as numbers
-		if(lhs.m_type == math_val_type::floating || rhs.m_type == math_val_type::floating)
-			// one floating: compare as floats
-			return lhs.get_double() == rhs.get_double();
-		else
-			// both ints: compare as ints
-			return lhs.get_integer() == rhs.get_integer();
+		// compare as both types, to ensure rounding errors don't return things like 0x5555555555555555 == 0x5555555555555556+511.0
+		// (but omit integer compare if that'd overflow)
+		return lhs.get_double() == rhs.get_double() && (fabs(lhs.get_double()) > INT64_MAX || lhs.get_integer() == rhs.get_integer());
 	}
 }
 


### PR DESCRIPTION
Still gives wrong answer for $4000000000000000\*3 == $4000000000000000\*3.0 (where former overflows to negative, but latter stays positive), but should fix
db equal($5555555555555555, $5555555555555555+1)
db equal($5555555555555555, $5555555555555555+1+511.0)
to not return 00 01, at least