### PR TITLE
fix file-helpers-linux.cpp warning

### DIFF
--- a/src/asar/platform/linux/file-helpers-linux.cpp
+++ b/src/asar/platform/linux/file-helpers-linux.cpp
@@ -56,6 +56,8 @@ FileHandleType open_file(const char* path, FileOpenMode mode, FileOpenError* err
 	case FileOpenMode_Write:
 		open_mode = "wb";
 		break;
+	default:
+		__builtin_unreachable();
 	}
 
 	out_handle = fopen(path, open_mode);


### PR DESCRIPTION
```
/home/asar-ci/asar/src/asar/platform/linux/file-helpers-linux.cpp: In function ‘FILE* open_file(const char*, FileOpenMode, FileOpenError*)’: /home/asar-ci/asar/src/asar/platform/linux/file-helpers-linux.cpp:61:27: warning: ‘open_mode’ may be used uninitialized [-Wmaybe-uninitialized]
   61 |         out_handle = fopen(path, open_mode);
      |                      ~~~~~^~~~~~~~~~~~~~~~~
/home/asar-ci/asar/src/asar/platform/linux/file-helpers-linux.cpp:46:21: note: ‘open_mode’ was declared here
   46 |         const char* open_mode;
      |                     ^~~~~~~~~
```